### PR TITLE
fix bug in process closefile function which may cause metaserver crash

### DIFF
--- a/meta/source/storage/InodeFileStore.cpp
+++ b/meta/source/storage/InodeFileStore.cpp
@@ -209,6 +209,10 @@ bool InodeFileStore::closeFile(EntryInfo* entryInfo, FileInode* inode, unsigned 
    if(iter != this->inodes.end() )
    { // outInode exists
 
+      FileInodeReferencer* inodeRefer = iter->second;
+      if(inodeRefer->getReferencedObject() != inode) 
+        return false;  
+      
       *outNumHardlinks = inode->getNumHardlinks();
 
       // Store inode information on disk, they have been set with inode->setDynAttribs() before


### PR DESCRIPTION
In InodeFileStore.cpp:closeFile，use entryID to search in the global inode map,  when found, the iter point to the "inode" which maybe different from the "inode" that the closeFile function use as input parameter.  In fact, the latter "inode" maybe in the parent dir's inode map but global inode map.  This mistake would make the reference count of inode wrong in subsequent request of closefile, and finally cause metaserver to coredump.  So add the condition to make the "inode" is what we found.   