### PR TITLE
feat: add support for multi-stream SSDs (such as FDP SSDs)

### DIFF
--- a/client_module/build/feature-detect.sh
+++ b/client_module/build/feature-detect.sh
@@ -193,6 +193,11 @@ run_job check_struct_field \
    inode::i_mtime \
    KERNEL_HAS_INODE_MTIME \
    linux/fs.h
+   
+run_job check_struct_field \
+   inode::i_write_hint \
+   KERNEL_HAS_INODE_I_WRITE_HINT \
+   linux/fs.h
 
 run_job check_struct_field \
    dentry::d_subdirs \

--- a/client_module/source/common/net/message/session/rw/WriteLocalFileMsg.c
+++ b/client_module/source/common/net/message/session/rw/WriteLocalFileMsg.c
@@ -41,4 +41,7 @@ void WriteLocalFileMsg_serializePayload(NetMessage* this, SerializeCtx* ctx)
 
    // targetID
    Serialization_serializeUShort(ctx, thisCast->targetID);
+
+   // writeHint
+   Serialization_serializeUInt64(ctx, thisCast->writeHint);
 }

--- a/client_module/source/common/net/message/session/rw/WriteLocalFileMsg.h
+++ b/client_module/source/common/net/message/session/rw/WriteLocalFileMsg.h
@@ -24,7 +24,7 @@ typedef struct WriteLocalFileMsg WriteLocalFileMsg;
 static inline void WriteLocalFileMsg_init(WriteLocalFileMsg* this);
 static inline void WriteLocalFileMsg_initFromSession(WriteLocalFileMsg* this,
    NumNodeID clientNumID, const char* fileHandleID, uint16_t targetID, PathInfo* pathInfo,
-   unsigned accessFlags, int64_t offset, int64_t count);
+   unsigned accessFlags, int64_t offset, int64_t count, uint64_t writeHint);
 
 // virtual functions
 extern void WriteLocalFileMsg_serializePayload(NetMessage* this, SerializeCtx* ctx);
@@ -51,6 +51,7 @@ struct WriteLocalFileMsg
    PathInfo* pathInfo;
    unsigned userID;
    unsigned groupID;
+   uint64_t writeHint;
 };
 
 extern const struct NetMessageOps WriteLocalFileMsg_Ops;
@@ -67,7 +68,7 @@ void WriteLocalFileMsg_init(WriteLocalFileMsg* this)
 void WriteLocalFileMsg_initFromSession(WriteLocalFileMsg* this,
    NumNodeID clientNumID, const char* fileHandleID, uint16_t targetID, PathInfo* pathInfo,
    unsigned accessFlags,
-   int64_t offset, int64_t count)
+   int64_t offset, int64_t count, uint64_t writeHint)
 {
    WriteLocalFileMsg_init(this);
 
@@ -83,6 +84,7 @@ void WriteLocalFileMsg_initFromSession(WriteLocalFileMsg* this,
 
    this->offset = offset;
    this->count = count;
+   this->writeHint = writeHint;
 }
 
 void WriteLocalFileMsg_setUserdataForQuota(WriteLocalFileMsg* this, unsigned userID,

--- a/client_module/source/common/net/message/session/rw/WriteLocalFileRDMAMsg.c
+++ b/client_module/source/common/net/message/session/rw/WriteLocalFileRDMAMsg.c
@@ -45,5 +45,8 @@ void WriteLocalFileRDMAMsg_serializePayload(NetMessage* this, SerializeCtx* ctx)
 
    // RDMA info
    RdmaInfo_serialize(ctx, thisCast->rdmap);
+
+   // writeHint
+   Serialization_serializeUInt64(ctx, thisCast->writeHint);
 }
 #endif /* BEEGFS_NVFS */

--- a/client_module/source/common/net/message/session/rw/WriteLocalFileRDMAMsg.h
+++ b/client_module/source/common/net/message/session/rw/WriteLocalFileRDMAMsg.h
@@ -26,7 +26,7 @@ typedef struct WriteLocalFileRDMAMsg WriteLocalFileRDMAMsg;
 static inline void WriteLocalFileRDMAMsg_init(WriteLocalFileRDMAMsg* this);
 static inline void WriteLocalFileRDMAMsg_initFromSession(WriteLocalFileRDMAMsg* this,
    NumNodeID clientNumID, const char* fileHandleID, uint16_t targetID, PathInfo* pathInfo,
-   unsigned accessFlags, int64_t offset, int64_t count, RdmaInfo *rdmap);
+   unsigned accessFlags, int64_t offset, int64_t count, uint64_t writeHint, RdmaInfo *rdmap);
 
 // virtual functions
 extern void WriteLocalFileRDMAMsg_serializePayload(NetMessage* this, SerializeCtx* ctx);
@@ -53,6 +53,7 @@ struct WriteLocalFileRDMAMsg
    PathInfo* pathInfo;
    unsigned userID;
    unsigned groupID;
+   uint64_t writeHint;
    RdmaInfo *rdmap;
 };
 
@@ -69,7 +70,7 @@ void WriteLocalFileRDMAMsg_init(WriteLocalFileRDMAMsg* this)
  */
 void WriteLocalFileRDMAMsg_initFromSession(WriteLocalFileRDMAMsg* this,
    NumNodeID clientNumID, const char* fileHandleID, uint16_t targetID, PathInfo* pathInfo,
-   unsigned accessFlags, int64_t offset, int64_t count, RdmaInfo *rdmap)
+   unsigned accessFlags, int64_t offset, int64_t count, uint64_t writeHint, RdmaInfo *rdmap)
 {
    WriteLocalFileRDMAMsg_init(this);
 
@@ -85,6 +86,7 @@ void WriteLocalFileRDMAMsg_initFromSession(WriteLocalFileRDMAMsg* this,
 
    this->offset = offset;
    this->count = count;
+   this->writeHint = writeHint;
 
    this->rdmap = rdmap;
 }

--- a/client_module/source/filesystem/FhgfsInode.c
+++ b/client_module/source/filesystem/FhgfsInode.c
@@ -473,9 +473,14 @@ void __FhgfsInode_initOpenIOInfo(FhgfsInode* this, FhgfsInodeFileHandle* fileHan
 
    outIOInfo->userID  = i_uid_read(&this->vfs_inode);
    outIOInfo->groupID = i_gid_read(&this->vfs_inode);
-   outIOInfo->writeHint = this->vfs_inode.i_write_hint;
 #ifdef BEEGFS_NVFS
    outIOInfo->nvfs = false;
+#endif
+
+#if defined(KERNEL_HAS_INODE_I_WRITE_HINT)
+   outIOInfo->writeHint = this->vfs_inode.i_write_hint;
+#else
+   outIOInfo->writeHint = RW_HINT_INVALID;
 #endif
 }
 

--- a/client_module/source/filesystem/FhgfsInode.c
+++ b/client_module/source/filesystem/FhgfsInode.c
@@ -473,6 +473,7 @@ void __FhgfsInode_initOpenIOInfo(FhgfsInode* this, FhgfsInodeFileHandle* fileHan
 
    outIOInfo->userID  = i_uid_read(&this->vfs_inode);
    outIOInfo->groupID = i_gid_read(&this->vfs_inode);
+   outIOInfo->writeHint = this->vfs_inode.i_write_hint;
 #ifdef BEEGFS_NVFS
    outIOInfo->nvfs = false;
 #endif

--- a/client_module/source/net/filesystem/FhgfsOpsCommKit.c
+++ b/client_module/source/net/filesystem/FhgfsOpsCommKit.c
@@ -1322,7 +1322,8 @@ static unsigned __commkit_writefile_prepareHeader(CommKitContext* context,
    {
       WriteLocalFileMsg_initFromSession(&writeMsg, localNodeNumID,
          context->ioInfo->fileHandleID, info->targetID, context->ioInfo->pathInfo,
-         context->ioInfo->accessFlags, currentState->offset, currentState->totalSize);
+         context->ioInfo->accessFlags, currentState->offset, currentState->totalSize, 
+		 context->ioInfo->writeHint);
 
       netMessage = &writeMsg.netMessage;
    }
@@ -1332,7 +1333,7 @@ static unsigned __commkit_writefile_prepareHeader(CommKitContext* context,
       WriteLocalFileRDMAMsg_initFromSession(&writeRDMAMsg, localNodeNumID,
          context->ioInfo->fileHandleID, info->targetID, context->ioInfo->pathInfo,
          context->ioInfo->accessFlags, currentState->offset, currentState->totalSize,
-         currentState->rdmap);
+         context->ioInfo->writeHint, currentState->rdmap);
 
       netMessage = &writeRDMAMsg.netMessage;
    }

--- a/client_module/source/net/filesystem/FhgfsOpsCommKitVec.c
+++ b/client_module/source/net/filesystem/FhgfsOpsCommKitVec.c
@@ -678,7 +678,7 @@ void __FhgfsOpsCommKitVec_writefileStagePREPARE(CommKitVecHelper* commHelper,
    // prepare message
    WriteLocalFileMsg_initFromSession(&writeMsg, localNodeNumID,
       commHelper->ioInfo->fileHandleID, comm->targetID, commHelper->ioInfo->pathInfo,
-      commHelper->ioInfo->accessFlags, offset, remainingDataSize);
+      commHelper->ioInfo->accessFlags, offset, remainingDataSize, commHelper->ioInfo->writeHint);
 
    NetMessage_setMsgHeaderTargetID( (NetMessage*)&writeMsg, nodeReferenceTargetID);
 

--- a/client_module/source/net/filesystem/RemotingIOInfo.h
+++ b/client_module/source/net/filesystem/RemotingIOInfo.h
@@ -7,6 +7,7 @@
 #include <toolkit/BitStore.h>
 #include <app/App.h>
 
+#define RW_HINT_INVALID 0xFF
 
 struct RemotingIOInfo;
 typedef struct RemotingIOInfo RemotingIOInfo;
@@ -79,6 +80,8 @@ void RemotingIOInfo_initOpen(App* app, unsigned accessFlags, AtomicInt* maxUsedT
 #ifdef BEEGFS_NVFS
    outIOInfo->nvfs = false;
 #endif
+   
+   outIOInfo->writeHint = RW_HINT_INVALID;
 }
 
 
@@ -105,6 +108,8 @@ void RemotingIOInfo_initSpecialClose(App* app, const char* fileHandleID,
 #ifdef BEEGFS_NVFS
    outIOInfo->nvfs = false;
 #endif
+
+   outIOInfo->writeHint = RW_HINT_INVALID;
 }
 
 /**

--- a/client_module/source/net/filesystem/RemotingIOInfo.h
+++ b/client_module/source/net/filesystem/RemotingIOInfo.h
@@ -44,6 +44,7 @@ struct RemotingIOInfo
 #ifdef BEEGFS_NVFS
       bool nvfs;
 #endif
+      uint64_t writeHint;
 };
 
 

--- a/common/source/common/net/message/session/rw/WriteLocalFileMsg.h
+++ b/common/source/common/net/message/session/rw/WriteLocalFileMsg.h
@@ -12,6 +12,7 @@
 #define WRITELOCALFILEMSG_FLAG_BUDDYMIRROR_SECOND  16 /* secondary of group, otherwise primary */
 #define WRITELOCALFILEMSG_FLAG_BUDDYMIRROR_FORWARD 32 /* forward msg to secondary */
 
+#define RW_HINT_INVALID 0xFF
 class WriteLocalFileMsgBase
 {
    public:
@@ -21,7 +22,7 @@ class WriteLocalFileMsgBase
        */
       WriteLocalFileMsgBase(const NumNodeID clientNumID, const char* fileHandleID,
          const uint16_t targetID, const PathInfo* pathInfo, const unsigned accessFlags,
-         const int64_t offset, const int64_t count)
+         const int64_t offset, const int64_t count, const unsigned writeHint)
       {
          this->clientNumID = clientNumID;
 
@@ -36,6 +37,7 @@ class WriteLocalFileMsgBase
 
          this->offset = offset;
          this->count = count;
+         this->writeHint = writeHint;
       }
 
       WriteLocalFileMsgBase() {}
@@ -57,7 +59,8 @@ class WriteLocalFileMsgBase
             % serdes::rawString(obj->fileHandleID, obj->fileHandleIDLen, 4)
             % obj->clientNumID
             % serdes::backedPtr(obj->pathInfoPtr, obj->pathInfo)
-            % obj->targetID;
+            % obj->targetID
+	    	% obj->writeHint;
       }
 
    protected:
@@ -71,7 +74,7 @@ class WriteLocalFileMsgBase
 
       uint32_t userID;
       uint32_t groupID;
-
+      uint64_t writeHint;
       // for serialization
       const PathInfo* pathInfoPtr;
 
@@ -126,6 +129,11 @@ class WriteLocalFileMsgBase
          return groupID;
       }
 
+      uint64_t getWriteHint() const
+      {
+          return writeHint;
+      }
+
       void setUserdataForQuota(unsigned userID, unsigned groupID)
       {
          this->userID = userID;
@@ -162,9 +170,9 @@ class WriteLocalFileMsg : public WriteLocalFileMsgBase, public NetMessageSerdes<
        */
       WriteLocalFileMsg(const NumNodeID clientNumID, const char* fileHandleID,
          const uint16_t targetID, const PathInfo* pathInfo, const unsigned accessFlags,
-         const int64_t offset, const int64_t count) :
+         const int64_t offset, const int64_t count, const uint64_t writeHint = RW_HINT_INVALID) :
          WriteLocalFileMsgBase(clientNumID, fileHandleID, targetID, pathInfo, accessFlags,
-            offset, count),
+            offset, count, writeHint),
             BaseType(NETMSGTYPE_WriteLocalFile) {}
 
       /**

--- a/common/source/common/net/message/session/rw/WriteLocalFileMsg.h
+++ b/common/source/common/net/message/session/rw/WriteLocalFileMsg.h
@@ -22,7 +22,7 @@ class WriteLocalFileMsgBase
        */
       WriteLocalFileMsgBase(const NumNodeID clientNumID, const char* fileHandleID,
          const uint16_t targetID, const PathInfo* pathInfo, const unsigned accessFlags,
-         const int64_t offset, const int64_t count, const unsigned writeHint)
+         const int64_t offset, const int64_t count, const uint64_t writeHint)
       {
          this->clientNumID = clientNumID;
 

--- a/common/source/common/net/message/session/rw/WriteLocalFileRDMAMsg.h
+++ b/common/source/common/net/message/session/rw/WriteLocalFileRDMAMsg.h
@@ -17,8 +17,8 @@ class WriteLocalFileRDMAMsg : public WriteLocalFileMsgBase, public NetMessageSer
        */
       WriteLocalFileRDMAMsg(const NumNodeID clientNumID, const char* fileHandleID,
          const uint16_t targetID, const PathInfo* pathInfo, const unsigned accessFlags,
-         const int64_t offset, const int64_t count) :
-         WriteLocalFileMsgBase(clientNumID, fileHandleID, targetID, pathInfo, accessFlags, offset, count),
+         const int64_t offset, const int64_t count, const uint64_t writeHint = RW_HINT_INVALID) :
+         WriteLocalFileMsgBase(clientNumID, fileHandleID, targetID, pathInfo, accessFlags, offset, count, writeHint),
          BaseType(NETMSGTYPE_WriteLocalFileRDMA) {}
 
       /**

--- a/storage/source/net/message/session/rw/WriteLocalFileMsgEx.cpp
+++ b/storage/source/net/message/session/rw/WriteLocalFileMsgEx.cpp
@@ -523,7 +523,8 @@ FhgfsOpsErr WriteLocalFileMsgExBase<Msg, WriteState>::openFile(const StorageTarg
 
    SessionQuotaInfo quotaInfo(useQuota, enforceQuota, getUserID(), getGroupID() );
 
-   FhgfsOpsErr openChunkRes = sessionLocalFile->openFile(targetFD, getPathInfo(), true, &quotaInfo);
+   FhgfsOpsErr openChunkRes = sessionLocalFile->openFile(targetFD, getPathInfo(), 
+   true, &quotaInfo, getWriteHint());
 
    return openChunkRes;
 }
@@ -638,7 +639,7 @@ FhgfsOpsErr WriteLocalFileMsgExBase<Msg, WriteState>::prepareMirroring(char* buf
          mirrorToSock = mirrorToNode->getConnPool()->acquireStreamSocket();
 
          WriteLocalFileMsg mirrorWriteMsg(getClientNumID(), getFileHandleID(), getTargetID(),
-            getPathInfo(), getAccessFlags(), getOffset(), getCount());
+            getPathInfo(), getAccessFlags(), getOffset(), getCount(), getWriteHint());
 
          if(doSessionCheck() )
             mirrorWriteMsg.addMsgHeaderFeatureFlag(WRITELOCALFILEMSG_FLAG_SESSION_CHECK);
@@ -733,7 +734,7 @@ FhgfsOpsErr WriteLocalFileMsgExBase<Msg, WriteState>::sendToMirror(const char* b
             mirrorToSock = mirrorToNode->getConnPool()->acquireStreamSocket();
 
             WriteLocalFileMsg mirrorWriteMsg(getClientNumID(), getFileHandleID(),
-               getTargetID(), getPathInfo(), getAccessFlags(), offset, toBeMirrored);
+               getTargetID(), getPathInfo(), getAccessFlags(), offset, toBeMirrored, getWriteHint());
 
             if(doSessionCheck() )
                mirrorWriteMsg.addMsgHeaderFeatureFlag(WRITELOCALFILEMSG_FLAG_SESSION_CHECK);

--- a/storage/source/net/message/session/rw/WriteLocalFileMsgEx.h
+++ b/storage/source/net/message/session/rw/WriteLocalFileMsgEx.h
@@ -160,6 +160,11 @@ class WriteLocalFileMsgExBase : public Msg
       {
          return static_cast<Msg&>(*this).getPathInfo();
       }
+
+      inline uint64_t getWriteHint() const
+      {
+         return static_cast<const Msg&>(*this).getWriteHint();
+      }
 };
 
 /**

--- a/storage/source/session/SessionLocalFile.cpp
+++ b/storage/source/session/SessionLocalFile.cpp
@@ -50,7 +50,7 @@ void SessionLocalFile::serializeNodeID(SessionLocalFile* obj, Deserializer& des)
  * @param isWriteOpen if set to true, the file will be created if it didn't exist.
  */
 FhgfsOpsErr SessionLocalFile::openFile(int targetFD, const PathInfo* pathInfo,
-   bool isWriteOpen, const SessionQuotaInfo* quotaInfo)
+   bool isWriteOpen, const SessionQuotaInfo* quotaInfo, uint64_t writeHint)
 {
    FhgfsOpsErr retVal = FhgfsOpsErr_SUCCESS;
 
@@ -94,7 +94,7 @@ FhgfsOpsErr SessionLocalFile::openFile(int targetFD, const PathInfo* pathInfo,
 
          FhgfsOpsErr openChunkRes = chunkDirStore->openChunkFile(
             targetFD, &chunkDirPath, chunkFilePathStr, hasOrigFeature, openFlags, &fd, quotaInfo,
-            exceededQuotaStore);
+            exceededQuotaStore, writeHint);
 
          // fix chunk path permissions
          if (unlikely(openChunkRes == FhgfsOpsErr_NOTOWNER && quotaInfo->useQuota) )
@@ -104,7 +104,7 @@ FhgfsOpsErr SessionLocalFile::openFile(int targetFD, const PathInfo* pathInfo,
 
             openChunkRes = chunkDirStore->openChunkFile(
                targetFD, &chunkDirPath, chunkFilePathStr, hasOrigFeature, openFlags, &fd,
-               quotaInfo, exceededQuotaStore);
+               quotaInfo, exceededQuotaStore, writeHint);
          }
 
          if (openChunkRes != FhgfsOpsErr_SUCCESS)

--- a/storage/source/session/SessionLocalFile.h
+++ b/storage/source/session/SessionLocalFile.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 
+#define RW_HINT_INVALID 0xFF
 /**
  * Represents the client session information for an open chunk file.
  */
@@ -97,7 +98,7 @@ class SessionLocalFile
       }
 
       FhgfsOpsErr openFile(int targetFD, const PathInfo* pathInfo, bool isWriteOpen,
-         const SessionQuotaInfo* quotaInfo);
+         const SessionQuotaInfo* quotaInfo, uint64_t writeHint = RW_HINT_INVALID);
 
       NodeHandle setMirrorNodeExclusive(NodeHandle mirrorNode);
 

--- a/storage/source/storage/ChunkStore.cpp
+++ b/storage/source/storage/ChunkStore.cpp
@@ -549,7 +549,7 @@ out:
 }
 
 std::pair<FhgfsOpsErr, int> ChunkStore::openAndChown(const int targetFD, const std::string& path,
-   const int openFlags, const SessionQuotaInfo& quota)
+   const int openFlags, const SessionQuotaInfo& quota, uint64_t writeHint)
 {
    // if we aren't using quota, we don't care about the file owner at all and may simply create the
    // file if it does exist (and if openFlags requests it).
@@ -583,6 +583,12 @@ std::pair<FhgfsOpsErr, int> ChunkStore::openAndChown(const int targetFD, const s
          return {FhgfsOpsErrTk::fromSysErr(errno), -1};
    }
 
+   int r = fcntl(fd, F_SET_RW_HINT, &writeHint);
+   if (r < 0) {
+      LOG(GENERAL, ERR, "Failed to set writeHint.",
+      ("writeHint", StringTk::uint64ToStr(writeHint)));
+   }
+
    if (!quota.useQuota)
       return {FhgfsOpsErr_SUCCESS, fd};
 
@@ -607,7 +613,7 @@ std::pair<FhgfsOpsErr, int> ChunkStore::openAndChown(const int targetFD, const s
  */
 FhgfsOpsErr ChunkStore::openChunkFile(int targetFD, const Path* chunkDirPath,
    const std::string& chunkFilePathStr, bool hasOrigFeature, int openFlags, int* outFD,
-   const SessionQuotaInfo* quotaInfo, const ExceededQuotaStorePtr exQuotaStore)
+   const SessionQuotaInfo* quotaInfo, const ExceededQuotaStorePtr exQuotaStore, uint64_t writeHint)
 {
    const char* logContext = "ChunkStore create chunkFile";
    FhgfsOpsErr retVal = FhgfsOpsErr_INTERNAL;
@@ -637,7 +643,7 @@ FhgfsOpsErr ChunkStore::openChunkFile(int targetFD, const Path* chunkDirPath,
       }
    }
 
-   std::tie(retVal, *outFD) = openAndChown(targetFD, chunkFilePathStr, openFlags, *quotaInfo);
+   std::tie(retVal, *outFD) = openAndChown(targetFD, chunkFilePathStr, openFlags, *quotaInfo, writeHint);
    if (retVal == FhgfsOpsErr_SUCCESS)
       return FhgfsOpsErr_SUCCESS;
 
@@ -665,7 +671,7 @@ FhgfsOpsErr ChunkStore::openChunkFile(int targetFD, const Path* chunkDirPath,
       }
 
       // dir created => try file open/create again...
-      std::tie(retVal, *outFD) = openAndChown(targetFD, chunkFilePathStr, openFlags, *quotaInfo);
+      std::tie(retVal, *outFD) = openAndChown(targetFD, chunkFilePathStr, openFlags, *quotaInfo, writeHint);
 
       if (lastChunkDirElement) // old V2 files do not get this
       {

--- a/storage/source/storage/ChunkStore.cpp
+++ b/storage/source/storage/ChunkStore.cpp
@@ -583,10 +583,15 @@ std::pair<FhgfsOpsErr, int> ChunkStore::openAndChown(const int targetFD, const s
          return {FhgfsOpsErrTk::fromSysErr(errno), -1};
    }
 
-   int r = fcntl(fd, F_SET_RW_HINT, &writeHint);
-   if (r < 0) {
-      LOG(GENERAL, ERR, "Failed to set writeHint.",
-      ("writeHint", StringTk::uint64ToStr(writeHint)));
+   if (writeHint != RW_HINT_INVALID)
+   {
+      int r = fcntl(fd, F_SET_RW_HINT, &writeHint);
+      if (r < 0) 
+	  {
+         LOG(GENERAL, ERR, 
+		 "Client requested a write lifetime hint, but server failed to set it.",
+         ("writeHint", StringTk::uint64ToStr(writeHint)), sysErr);
+	  }
    }
 
    if (!quota.useQuota)

--- a/storage/source/storage/ChunkStore.h
+++ b/storage/source/storage/ChunkStore.h
@@ -11,9 +11,14 @@
 
 #include "ChunkDir.h"
 
+#define RW_HINT_INVALID 0xFF
 
 #define PATH_DEPTH_IDENTIFIER 'l' // we use 'l' (level) instead of 'd', as d is part of hex numbers
 
+#ifndef F_SET_RW_HINT
+#define F_LINUX_SPECIFIC_BASE 1024
+#define F_SET_RW_HINT (F_LINUX_SPECIFIC_BASE + 12)
+#endif
 
 class ChunkDir;
 
@@ -55,7 +60,7 @@ class ChunkStore
 
       FhgfsOpsErr openChunkFile(int targetFD, const Path* chunkDirPath,
          const std::string& chunkFilePathStr, bool hasOrigFeature, int openFlags, int* outFD,
-         const SessionQuotaInfo* quotaInfo, const ExceededQuotaStorePtr exQuotaStore);
+         const SessionQuotaInfo* quotaInfo, const ExceededQuotaStorePtr exQuotaStore, uint64_t writeHint = RW_HINT_INVALID);
 
       bool chmodV2ChunkDirPath(int targetFD, const Path* chunkDirPath, const std::string& entryID);
 
@@ -87,7 +92,7 @@ class ChunkStore
          ChunkDir** outChunkDir);
 
       std::pair<FhgfsOpsErr, int> openAndChown(const int targetFD, const std::string& path,
-         const int openFlags, const SessionQuotaInfo& quota);
+         const int openFlags, const SessionQuotaInfo& quota, uint64_t writeHint = RW_HINT_INVALID);
 
       // inlined
 


### PR DESCRIPTION
_The NVMe SSD (e.g. Flexible Data Placement SSD, TP4146)_ is supporting to recognize data lifetime information on device. Adding data lifetime information (writeHint) that passed to the devices to achieve lower write amplification and better performance.
Kernel file-systems (ext4, XFS, btrfs, F2FS) have already supported to set the writeHint by fcntl(). This patch adds support for data lifetime information in BeeGFS, and it enables BeeGFS to use multi-stream SSDs, such as FDP SSDs. 
A brief proposal for this feature is here:  https://github.com/ThinkParQ/beegfs/issues/59

The following provides an overview of the FDP technology, the current state of kernel support, the design of this patch, and the benchmark results.

### FDP Technology
_Flexible Data Placement (FDP)_ is a new data placement technology has been merged in NVMe specification v2.1. FDP SSDs can reduce write amplification (WAF) due to the allowance of  the host to control where data are written according to the data lifetime. 

**In summary, the biggest advantage of FDP compared to conventional SSDs lies in the flexibility it provides to the host—enabling precise control over data placement into isolated Reclaim Units (RUs) via Reclaim Unit Handles (RUHs).** This feature allows developers to place data with similar lifetimes into the same RU. As a result, during garbage collection (GC), most data in an RU becomes invalid simultaneously, significantly reducing the amount of valid data that needs to be migrated. This greatly lowers write amplification and extends device lifespan.
```
                 Conventional SSD                                           FDP SSD
+---------------------------------------------------+ +---------------------------------------------------+ 
|				 Host Data Streams				    | |	       		   Host Data Streams				  |
|	+-------+   +-------+   +-------+   +-------+   | |	  +-------+   +-------+   +-------+   +-------+   |
|	|   1   |   |   2   |   |   3   |   |   4   |   | |	  |   1   |   |   2   |   |   3   |   |   4   |   |
|	+-------+   +-------+   +-------+   +-------+   | |	  +-------+   +-------+   +-------+   +-------+   |
+---------------------------------------------------+ +---------------------------------------------------+
+---------------------------------------------------+ +---------------------------------------------------+
|                       SSD                         | |                       SSD                         |
|   +-------------------------------------------+   | |   +-------------------------------------------+   |
|	|					FTL					    |	| |	  |					  FTL					  |	  |
|	+-------------------------------------------+	| |	  +-------------------------------------------+	  |
|   +---+---+---+---+---+---+---+---+---+---+---+   | |   +-----+    +-----+         +-----+    +-----+   |
|	| 2 | 4 | 1 | 3 | 2 | 3 | 4 | 1 | 2 | 2 | 4 |   | |   |  1  |    |  1  |         |  3  |    |  3  |   |
|	+---+---+---+---+---+---+---+---+---+---+---+   | |   +-----+    +-----+         +-----+    +-----+   |
|	| 3 | 1 | 4 | 2 | 3 | 1 | 1 | 2 | 1 | 3 | 1 |   | |   +-----+    +-----+         +-----+    +-----+   |
|	+---+---+---+---+---+---+---+---+---+---+---+   | |   |  2  |    |  2  |         |  4  |    |  4  |   |
|	| 4 | 2 | 3 | 1 | 2 | 2 | 1 | 4 | 3 | 2 | 3 |   | |   +-----+    +-----+         +-----+    +-----+   |
|	+---+---+---+---+---+---+---+---+---+---+---+   | |   +-----+    +-----+         +-----+    +-----+   |
|	| 1 | 3 | 2 | 4 | 3 |   |   |   |   |   |   |   | |   |  1  |    |  2  |         |     |    |     |   |
|	+---+---+---+---+---+---+---+---+---+---+---+   | |   +-----+    +-----+         +-----+    +-----+   |
|	|   |   |   |   |   |   |   |   |   |   |   |   | |   <-RU-->                                         |
|	+---+---+---+---+---+---+---+---+---+---+---+   | |   <-------RG0------>         <-------RG1------>   |
+---------------------------------------------------+ +---------------------------------------------------+

```
### Current Kernel Support for FDP
Since commit [449813515d3e](https://github.com/torvalds/linux/commit/449813515d3e) (_block, fs: Restore the per-bio/request data lifetime fields_), both file systems (f2fs, ext4, btrfs) and the block layer in the Linux kernel have supported data lifetime fields. The key fields involved are _i_write_hint_ in _inode_ and _bi_write_hint_ in _bio_.

In 2025, commit [38e8397dde63](https://github.com/torvalds/linux/commit/38e8397dde63) (_nvme: use fdp streams if write stream is provided_) extended the kernel driver to support FDP functionality. Notably, _bi_write_stream_ is essentially redundant with _bi_write_hint_—personally, I don’t fully understand why the kernel community accepted a new, redundant field after _bi_write_hint_ already existed.

### BeeGFS Support for FDP
This patch adds FDP support to BeeGFS. As described in the initial pull request: "This patch adds support for data lifetime information in BeeGFS, and it enables BeeGFS to use multi-stream SSDs, such as FDP SSDs."

We have modified three I/O paths in BeeGFS—**direct I/O, buffered I/O, and page cache I/O (use the kernel pagecache)**—to accept data lifetime hints from the kernel, propagate them through the network, and ultimately deliver them to the storage server, where they are used to direct data placement via FDP commands. The overall design can be simply summarized as shown in the figure below.
```
		  VFS_Inode                  RemotingIOInfo              WriteLocalFileMsg
	+---------------------+      +---------------------+      +---------------------+ 
	|  enum i_write_hint  + ---> |  unit64_t writeHint + ---> |  +---------------+  |
	+---------------------+      +---------------------+      |  |   NetMessage  |  |
															  |  +---------------+  |
															  |  unit64_t writeHint |
															  +----------+----------+
															   serialize to payload
																		 |
																		 v
Client														  +---------------------+
—————————————————————— TCP/IP or RDMA ——————————————————————— |         CTX         | ————
Server														  +----------+----------+ 
               +--------------- get writeHint -------------+   deserialize to member
			   | 										   |		     |
			   v					WriteLocalFileMsg      |		     v
	+---------------------+		 +---------------------+   |  +---------------------+
	|	   openFile		  |	<--- +  +---------------+  | <-+- +  unit64_t writeHint |
	+----------+----------+		 |  |  NetMessage   |  |	  +---------------------+
			   |				 |	+---------------+  |	   WriteLocalFileMsgBase
			   |                 |  +---------------+  |
			   v                 |  | WriteLocalFile|  |                    
    +---------------------+      |  |     MsgBase   |  |
    |	     fcntl        |      |  +---------------+  |
	+---------------------+      +---------------------+

```
### BeeGFS Benchmark Results
Since FDP technology significantly reduces write amplification through intelligent data placement based on data lifetime, we conducted comparative testing of BeeGFS on conventional SSDs versus FDP SSDs, focusing on WAF metric.

**Test Config**
To measure WAF, we first performed a precondition write to fill the disk to over 90% of its capacity (the disk is 8TB), and then conducted the WAF test.
We used FIO for testing, with FDP configured to use six streams (0–5). When testing the FDP SSD, user data was categorized into four lifetime hints—short, medium, long, and extreme—and each hint was written into a separate stream (streams 2–5). All remaining data was directed to stream 0, while stream 1 was left unused.
WAF was measured across all three I/O paths: direct I/O, buffered I/O, and page cache I/O.

**Test Results**
The maximum reduction in WAF reached 40%. In all cases, the WAF approached 1, indicating minimal to no write amplification on the device.

| I/O path       | Conventional SSDs | FDP SSDs           |
|----------------|------------------|-------------------|
| DIO            | 1.68             | 1.01 (↓39.88%)    |
| Buffer I/O     | 1.70             | 1.01 (↓40.59%)    |
| PageCache I/O  | 1.61             | 1.01 (↓37.27%)    |

In conclusion, this patch demonstrably reduces WAF substantially, validating its effectiveness in reducing WAF by utilizing the FDP feature.

